### PR TITLE
Handle JSON code fences without final newline

### DIFF
--- a/python/helpers/files.py
+++ b/python/helpers/files.py
@@ -259,7 +259,9 @@ def remove_code_fences(text):
 
 def is_full_json_template(text):
     # Pattern to match the entire text enclosed in ```json or ~~~json fences
-    pattern = r"^\s*(```|~~~)\s*json\s*\n(.*?)\n\1\s*$"
+    # The newline before the closing fence is optional to support inputs like
+    # "```json\n{"a": 1}```" which previously failed to match.
+    pattern = r"^\s*(```|~~~)\s*json\s*\n(.*?)\n?\1\s*$"
     # Use re.DOTALL to make '.' match newlines
     match = re.fullmatch(pattern, text.strip(), flags=re.DOTALL)
     return bool(match)

--- a/tests/test_is_full_json_template.py
+++ b/tests/test_is_full_json_template.py
@@ -1,0 +1,12 @@
+import pytest
+from python.helpers.files import is_full_json_template
+
+
+def test_handles_missing_trailing_newline():
+    text = "```json\n{\"a\": 1}```"
+    assert is_full_json_template(text)
+
+
+def test_handles_trailing_newline():
+    text = "```json\n{\"a\": 1}\n```"
+    assert is_full_json_template(text)


### PR DESCRIPTION
## Summary
- allow `is_full_json_template` to accept JSON code blocks without a newline before the closing fence
- add regression tests covering JSON templates with and without trailing newlines

## Testing
- `PYTHONPATH=. pytest tests/test_is_full_json_template.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'python')*

------
https://chatgpt.com/codex/tasks/task_b_6899e161a1b4832bbbd17666d7fb110a