### PR TITLE
docs: fix macOS naming

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ This guide will show you how to setup a local development environment for Agent 
 4. (optional) Git/GitHub
 
 > [!NOTE]
-> I will be using clean VS Code, Conda and Docker Desktop in this example on MacOS.
+> I will be using clean VS Code, Conda and Docker Desktop in this example on macOS.
 
 
 ## Step 0: Install required software

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ The following user guide provides instructions for installing and running Agent 
 <br><br>
 
 > [!NOTE]
-> **MacOS Configuration:** In Docker Desktop's preferences (Docker menu) → Settings → 
+> **macOS Configuration:** In Docker Desktop's preferences (Docker menu) → Settings → 
 > Advanced, enable "Allow the default Docker socket to be used (requires password)."
 
 ![docker socket macOS](res/setup/macsocket.png)


### PR DESCRIPTION
## Summary
- correct "MacOS" to "macOS" in installation guide
- ensure development manual uses "macOS" spelling

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'python')*


------
https://chatgpt.com/codex/tasks/task_b_6899e26416b0832b9752fbfced5a903f