### PR TITLE
Prevent shared list state in TaskPlan.create

### DIFF
--- a/python/helpers/task_scheduler.py
+++ b/python/helpers/task_scheduler.py
@@ -63,7 +63,14 @@ class TaskPlan(BaseModel):
     done: list[datetime] = Field(default_factory=list)
 
     @classmethod
-    def create(cls, todo: list[datetime] = list(), in_progress: datetime | None = None, done: list[datetime] = list()):
+    def create(
+        cls,
+        todo: Optional[list[datetime]] = None,
+        in_progress: datetime | None = None,
+        done: Optional[list[datetime]] = None,
+    ):
+        todo = todo or []
+        done = done or []
         if todo:
             for idx, dt in enumerate(todo):
                 if dt.tzinfo is None:

--- a/python/helpers/task_scheduler_test.py
+++ b/python/helpers/task_scheduler_test.py
@@ -1,0 +1,9 @@
+from python.helpers.task_scheduler import TaskPlan
+
+
+def test_task_plan_create_returns_distinct_lists():
+    plan_one = TaskPlan.create()
+    plan_two = TaskPlan.create()
+    assert plan_one.todo is not plan_two.todo
+    assert plan_one.done is not plan_two.done
+


### PR DESCRIPTION
## Summary
- fix TaskPlan.create to use optional todo/done lists and initialize them internally
- add a unit test confirming TaskPlan.create returns distinct list instances

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899e29215d8832b9315dc06dc253454