### PR TITLE
Use safe expression evaluator in vector DB

### DIFF
--- a/python/helpers/vector_db.py
+++ b/python/helpers/vector_db.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Sequence
 import uuid
 from langchain_community.vectorstores import FAISS
+from simpleeval import simple_eval
 
 # faiss needs to be patched for python 3.12 on arm #TODO remove once not needed
 from python.helpers import faiss_monkey_patch
@@ -151,9 +152,9 @@ def cosine_normalizer(val: float) -> float:
 def get_comparator(condition: str):
     def comparator(data: dict[str, Any]):
         try:
-            result = eval(condition, {}, data)
+            result = simple_eval(condition, names=data)
             return result
-        except Exception as e:
+        except Exception:
             # PrintStyle.error(f"Error evaluating condition: {e}")
             return False
 


### PR DESCRIPTION
## Summary
- Replace unsafe eval with simple_eval for metadata filtering in vector database.

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899eb088e1c832bb4acd3e7e591feae